### PR TITLE
Feature Implementation: Line Numbers

### DIFF
--- a/project/package/CodeEditor.vue
+++ b/project/package/CodeEditor.vue
@@ -88,7 +88,7 @@
       >
         <code
             v-highlight="contentValue"
-            :class="languageClass"
+            :class="(count_lines) ? `${languageClass} count-lines`: languageClass"
             :style="{ top: top + 'px', left: left + 'px', fontSize: font_size, borderBottomLeftRadius: read_only == true ? border_radius : 0, borderBottomRightRadius: read_only == true ? border_radius : 0 }"
         ></code>
       </pre>
@@ -108,6 +108,10 @@ export default {
   },
   name: "CodeEditor",
   props: {
+    count_lines:{
+      type: Boolean,
+      default: false
+    },
     modelValue: {
       type: String,
     },
@@ -384,6 +388,21 @@ export default {
   display: block;
   border: none;
   margin: 0;
+}
+
+count-lines{
+  counter-reset: line;
+}
+.count-lines:deep(span.hljs-tag){
+  counter-increment: line;
+}
+.count-lines:deep(span.hljs-tag:before){
+  content: counter(line);
+  position: absolute;
+  left: 5px;
+  font-size: 8px;
+  color: #777777;
+  padding-top: 4px;
 }
 
 /* hide_header */


### PR DESCRIPTION
With those simple changes you add a new prop named "count_lines" default false, if parsed true this enable the css class "count-lines" into code mark, showing in this way the line's number at the left

<img width="739" alt="Schermata 2022-09-28 alle 17 17 45" src="https://user-images.githubusercontent.com/36926081/192818360-bc1e6c62-0a20-47b9-b26a-63bd229a3733.png">
