### PR TITLE
Feaure: Line numbers & Disable Spellcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Simple CodeEditor for Vue.js
 
+
+
+
 website: [simple-code-editor.vicuxd.com](https://simple-code-editor.vicuxd.com)
 
 It's easy to use, both support read-only and edit mode, you can directly use it in the browser or import the JavaScript modules via the NPM package
@@ -138,6 +141,25 @@ Description: setting the contents of a code editor. If you want to bind the data
 Description: varies based on the value of form inputs element or output of components, the specific usage you can read [Vue.js Documentation](https://v3.vuejs.org/api/directives.html#v-model)
 
 
+### count_lines `Boolean`
+
+Default: `true`
+
+Description: whether line numbers should be displayed or not
+
+```html
+<CodeEditor :count_lines="true"></CodeEditor>
+```
+
+### spellcheck `Boolean`
+
+Default: `false`
+
+Description: whether spellcheck should be enabled on the code editor or not
+
+```html
+<CodeEditor :spellcheck="true"></CodeEditor>
+```
 
 
 ### language_selector `Boolean`

--- a/project/package/CodeEditor.vue
+++ b/project/package/CodeEditor.vue
@@ -356,6 +356,7 @@ export default {
 .line-numbers {
   width: 20px;
   text-align: right;
+  line-height: 1.5;
 }
 
 .line-numbers:deep(span) {

--- a/project/package/CodeEditor.vue
+++ b/project/package/CodeEditor.vue
@@ -491,11 +491,14 @@ export default {
 }
 
 /* scroll */
-/* .scroll>.code_area { */
+
+.scroll {
+  display: flex; 
+}
+
 .scroll > .editor {
   height: calc(100% - 34px);
   overflow: auto;
-  display: flex;
 }
 
 /* .scroll>.code_area>textarea { */

--- a/project/package/CodeEditor.vue
+++ b/project/package/CodeEditor.vue
@@ -240,21 +240,17 @@ export default {
     numberlines: {
       //vue2
       componentUpdated(el, binding) {
-          const lineNumbers = document.querySelector('.line-numbers')
-
           const numberOfLines = binding.value.split('\n').length
 
-          lineNumbers.innerHTML = Array(numberOfLines - 1)
+          el.innerHTML = Array(numberOfLines - 1)
             .fill('<span></span>')
             .join('')
       },
       //vue3
       updated(el, binding) {
-          const lineNumbers = document.querySelector('.line-numbers')
-
           const numberOfLines = binding.value.split('\n').length
 
-          lineNumbers.innerHTML = Array(numberOfLines - 1)
+          el.innerHTML = Array(numberOfLines - 1)
             .fill('<span></span>')
             .join('')
       }

--- a/project/package/CodeEditor.vue
+++ b/project/package/CodeEditor.vue
@@ -492,7 +492,7 @@ export default {
 
 /* scroll */
 
-.scroll {
+.editor {
   display: flex; 
 }
 

--- a/project/package/README.md
+++ b/project/package/README.md
@@ -141,6 +141,25 @@ Description: setting the contents of a code editor. If you want to bind the data
 Description: varies based on the value of form inputs element or output of components, the specific usage you can read [Vue.js Documentation](https://v3.vuejs.org/api/directives.html#v-model)
 
 
+### count_lines `Boolean`
+
+Default: `true`
+
+Description: whether line numbers should be displayed or not
+
+```html
+<CodeEditor :count_lines="true"></CodeEditor>
+```
+
+### spellcheck `Boolean`
+
+Default: `false`
+
+Description: whether spellcheck should be enabled on the code editor or not
+
+```html
+<CodeEditor :spellcheck="true"></CodeEditor>
+```
 
 
 ### language_selector `Boolean`


### PR DESCRIPTION
Adds the ability to enable line numbers in the editor and the ability to enable/disable spellcheck. Unlike #22 , this implementation uses javascript instead of css. The main benefit of this is that every line can be given a number (as opposed to just lines with highlights on them) and we do not assign duplicate highlight numbers if multiple highlights appear on the same line. 