### PR TITLE
add property 'default-langeage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,28 @@ Description: [["language name", "display name"], ["language name", "display name
 <CodeEditor :languages="[['cpp', 'C++']]" />
 ```
 
+### defaultLanguage `Array`
+
+Default: `[]`
+
+Description: ["language name", "display name"]. the language name is necessary, and the display name is optional
+
+```html
+<CodeEditor
+  :default-language=['markdown','Markdown']
+  :languages="[
+    ["c", "C"],
+    ["cpp", "C++"],
+    ["java", "Java"],
+    ["javascript", "JavaScript"],
+    ["typescript", "TypeScript"],
+    ["markdown", "Markdown"],
+    ["python", "Python"],
+    ["php", "PHP"]
+  ]"
+/>
+```
+
 Multiple languages:
 
 ```html

--- a/npm-package/CodeEditor.vue
+++ b/npm-package/CodeEditor.vue
@@ -173,6 +173,10 @@ export default {
       type: String,
       default: "12px",
     },
+    defaultLanguage: {
+      type: Array,
+      default: [],
+    },
     languages: {
       type: Array,
       default: function () {
@@ -234,8 +238,10 @@ export default {
       scrollBarHeight: 0,
       top: 0,
       left: 0,
-      languageClass: "hljs language-" + this.languages[0][0],
-      languageTitle: this.languages[0][1] ? this.languages[0][1] : this.languages[0][0],
+      languageClass: "hljs language-" + (this.defaultLanguage[0] || this.languages[0][0]),
+      languageTitle: this.defaultLanguage.length > 0 ?
+        (this.defaultLanguage[1] ? this.defaultLanguage[1] : this.defaultLanguage[0]) :
+        (this.languages[0][1] ? this.languages[0][1] : this.languages[0][0]),
       content: this.value,
       cursorPosition: 0,
       insertTab: false,


### PR DESCRIPTION
Previously, the default language was the first element of "languages" array.
When I want to change the default language, I have to rearrange the order of the array, or delete most of its elements, 
but this results in the deleted options being unable to be reselected.