### PR TITLE
Fix to issue #52 Highlighting not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,3 +347,17 @@ focus(node) {
   node.focus();
 }
 ```
+
+### @paste
+
+Description: passes the value inserted by the user
+
+```html
+<CodeEditor @paste="getValue"></CodeEditor>
+```
+
+```javascript
+getValue(pasteValue){
+    console.log(pasteValue);
+}
+```

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -347,3 +347,17 @@ focus(node) {
   node.focus();
 }
 ```
+
+### @paste
+
+Description: passes the value inserted by the user
+
+```html
+<CodeEditor @paste="getValue"></CodeEditor>
+```
+
+```javascript
+getValue(pasteValue){
+    console.log(pasteValue);
+}
+```

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -27,6 +27,6 @@
   },
   "homepage": "https://simple-code-editor.vicuxd.com",
   "dependencies": {
-    "highlight.js": "^11.8.0"
+    "highlight.js": "^11.11.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "highlight.js": "^11.8.0",
-    "vue": "^3.2.47"
+    "highlight.js": "^11.11.0",
+    "vue": "^3.5.13"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.1.0",

--- a/website/src/views/template.html
+++ b/website/src/views/template.html
@@ -1411,6 +1411,25 @@ export default {
         :read-only="true"
         width="100%"
       ></CodeEditor>
+
+        <h3>@paste</h3>
+        <p>Description: passes the value inserted by the user</p>
+        <CodeEditor
+            value='<CodeEditor @paste="getValue"></CodeEditor>'
+            :languages="[['html', 'HTML']]"
+            :theme="theme"
+            :read-only="true"
+            width="100%"
+        ></CodeEditor>
+        <CodeEditor
+                value="getValue(pasteValue) {
+  console.log(pasteValue);
+}"
+                :languages="[['javascript', 'JS']]"
+                :theme="theme"
+                :read-only="true"
+                width="100%"
+        ></CodeEditor>
     </div>
   </div>
   <!-- footer -->


### PR DESCRIPTION
The problem: Syntax highlighting didn't work on the highlight version.js above 11.8.0.
Error text: "Element previously highlighted. To highlight again, first unset `dataset.highlighted`".
Issue #52 

Solution: I use Highlight Auto along with highlightElement.

Also: 
1. Code Editor was rewritten to CompositionAPI, which made it more convenient to use the v-model.
2. Emit '@paste' has been added, which passes the inserted value so that you can check it for your own purposes. The documentation describes this issue.
3. Updated vue versions to '3.5.13' and' highlight.js 'before '11.11.0'